### PR TITLE
Fix tests and warnings.

### DIFF
--- a/Trell.Engine/Extensibility/SQLiteApi.cs
+++ b/Trell.Engine/Extensibility/SQLiteApi.cs
@@ -106,7 +106,7 @@ namespace Trell.Engine.Extensibility {
                 }
             }
 
-            public async Task<SQLiteConn> Open(dynamic options = null) {
+            public async Task<SQLiteConn> Open(dynamic? options = null) {
                 var context = this.Context.Value!;
                 context.CancellationToken.ThrowIfCancellationRequested();
                 var dbName = options?.dbname as string ?? "default";

--- a/Trell.Test/ClearScriptWrappers/TrellDocumentLoaderTest.cs
+++ b/Trell.Test/ClearScriptWrappers/TrellDocumentLoaderTest.cs
@@ -2,8 +2,12 @@ using static Trell.Engine.ClearScriptWrappers.EngineWrapper.TrellDocumentLoader;
 
 namespace Trell.Test.ClearScriptWrappers;
 
-public class TrellDocumentLoaderTest {
-    static readonly string[] DIR_SUFFIXES = ["", "/", "\\"];
+public class TrellDocumentLoaderTest(ITestOutputHelper output) {
+    static readonly string[] DIR_SUFFIXES = [
+        "",
+        Path.DirectorySeparatorChar.ToString(),
+        Path.AltDirectorySeparatorChar.ToString()
+    ];
     static readonly string[] FILE_PREFIXES = ["", "./"];
 
     [Theory]
@@ -13,8 +17,10 @@ public class TrellDocumentLoaderTest {
     [InlineData("/foo", "/foo/bax/zip", "../../../foo/bax/bar")]
     public void TestGoodPaths(string root, string dir, string file) {
         foreach (var (rootSlash, dirSlash, filePre) in Permutations(DIR_SUFFIXES, DIR_SUFFIXES, FILE_PREFIXES)) {
-            Assert.True(TryGetRootedPath(root + rootSlash, dir + dirSlash, filePre + file, out var path));
+            var res = TryGetRootedPath(root + rootSlash, dir + dirSlash, filePre + file, out var path);
+            output.WriteLine($"Path:  {path}");
             Assert.Equal(Path.GetFullPath(Path.Combine(dir, file)), path);
+            Assert.True(res);
         }
     }
 

--- a/Trell.Test/Usings.cs
+++ b/Trell.Test/Usings.cs
@@ -4,3 +4,4 @@ global using System.IO;
 global using System.Threading;
 global using System.Threading.Tasks;
 global using Xunit;
+global using Xunit.Abstractions;


### PR DESCRIPTION
The test was using / and \ as directory separators since Windows allows
both. On Linux, using \ fails as it's not a directory separator. That
behavior seemed fine so the test now uses Path.DirectorySeparatorChar
and Path.AltDirectorySeparatorChar which on Linux are both / and passes.