### PR TITLE
Hide full source paths from the user.

### DIFF
--- a/Trell.Engine/ClearScriptWrappers/EngineWrapper.cs
+++ b/Trell.Engine/ClearScriptWrappers/EngineWrapper.cs
@@ -112,13 +112,19 @@ public class EngineWrapper : IDisposable {
             var dir = settings.SearchPath;
             if (sourceInfo is DocumentInfo docInfo && docInfo.Uri is Uri docUri) {
                 dir = Path.GetDirectoryName(docUri.AbsolutePath) ?? "";
+                // Relocate the parent's including directory underneath the
+                // root directory search path (the worker's src).
+                dir = Path.Join(root, dir);
             }
 
             var extensions = settings.FileNameExtensions.Split(";");
 
             if (TryGetRootedPath(root, dir, specifier, out var path)
                 && File.Exists(path) && extensions.Contains(Path.GetExtension(path))) {
-                var uri = new Uri(path);
+                // The paths we give to ClearScript appear to be at / so that
+                // we can hide the actual path from the user.
+                var pathUnderRoot = path.Substring(root.Length);
+                var uri = new Uri("file://" + pathUnderRoot, UriKind.Absolute);
                 var info = new DocumentInfo(uri) {
                     Category = category,
                     ContextCallback = contextCallback,

--- a/Trell/IPC/Worker/TrellWorkerCore.cs
+++ b/Trell/IPC/Worker/TrellWorkerCore.cs
@@ -100,6 +100,9 @@ sealed class TrellWorkerCore : IDisposable, IWorkerClient {
                 }
                 workResult.Message = ex.Message;
                 workResult.Stacktrace = ex.StackTrace;
+                if (ex is ScriptEngineException scriptEx) {
+                    workResult.ScriptError = scriptEx.ErrorDetails;
+                }
             }
 
             return workResult;

--- a/Trell/Protos/Work.proto
+++ b/Trell/Protos/Work.proto
@@ -37,6 +37,7 @@ message WorkResult {
   ResultCode code = 1;
   string message = 2;
   optional string stacktrace = 3;
+  optional string scriptError = 4;
 }
 
 // Execution constraints.


### PR DESCRIPTION
This should work (at least in the sense that scripts will still run), but I don't know if it'll fix the stacktrace thing you ran into.