### PR TITLE
Allow specifying the shared database directory in the WorkOrder.

### DIFF
--- a/Trell/IPC/Worker/TrellWorkerImpl.cs
+++ b/Trell/IPC/Worker/TrellWorkerImpl.cs
@@ -48,14 +48,16 @@ public class TrellWorkerImpl : Rpc.TrellWorker.TrellWorkerBase, IDisposable {
             if (this.extensionContainer.Storage != null) {
                 var sharedConnector = Connector(
                     this.extensionContainer.Storage,
-                    $"users/{request.User.UserId}/data"
+                    string.IsNullOrEmpty(request.SharedDatabasesPath)
+                        ? $"users/{request.User.UserId}/data"
+                        : request.SharedDatabasesPath
                 );
 
                 var workerConnector = Connector(
                     this.extensionContainer.Storage,
                     string.IsNullOrEmpty(request.Workload.DataPath)
-                      ? $"users/{request.User.UserId}/workers/{request.Workload.WorkerId}/data"
-                      : request.Workload.DataPath
+                        ? $"users/{request.User.UserId}/workers/{request.Workload.WorkerId}/data"
+                        : request.Workload.DataPath
                 );
 
                 plugins.Add(new SQLiteApi(sharedConnector, workerConnector, request.SharedDatabases.ToList()));

--- a/Trell/Protos/Work.proto
+++ b/Trell/Protos/Work.proto
@@ -17,6 +17,7 @@ message WorkOrder {
   WorkLimits limits = 4;
   bytes metadata = 6;
   repeated string sharedDatabases = 7;
+  optional string sharedDatabasesPath = 8;
 }
 
 // Response.


### PR DESCRIPTION
This is needed to enable the `--shared-db-dir` option for `trell run`.