### PR TITLE
Make `trell run` execute in-process without server/worker.

### DIFF
--- a/Trell/CliCommands/RunCommand.cs
+++ b/Trell/CliCommands/RunCommand.cs
@@ -5,6 +5,8 @@ using Serilog.Events;
 using Spectre.Console.Cli;
 using System.ComponentModel;
 using System.Text.Json;
+using Trell.Engine.ClearScriptWrappers;
+using Trell.Extensions;
 using Trell.IPC.Server;
 
 namespace Trell.CliCommands;
@@ -83,35 +85,28 @@ public abstract class RunCommand<T> : AsyncCommand<T> where T : RunCommandSettin
         settings.Validate();
         App.BootstrapLogger(settings.LogLevel);
         var config = TrellConfig.LoadToml(settings.Config ?? "Trell.toml");
-        var args = context.Remaining.Raw.ToArray();
-        using var app = App.InitServer(config, args);
-        await app.StartAsync();
 
-        try {
-            var serverSocket = config.Socket;
+        var extensionContainer = TrellSetup.ExtensionContainer(config);
+        var runtimeWrapper = new RuntimeWrapper(extensionContainer, config.ToRuntimeConfig());
+        var worker = new IPC.Worker.TrellWorkerImpl(config, extensionContainer, runtimeWrapper);
 
-            Log.Information("Run: Connecting to {s}", serverSocket);
+        Log.Information("Run: Executing worker in-process.");
 
-            var serverCh = Utility.CreateUnixDomainSocketChannel(serverSocket);
-            var client = new Rpc.TrellServer.TrellServerClient(serverCh);
-
-            async Task<Rpc.WorkResult> Exec() {
-                var workOrder = GetServerWorkOrder(settings, config);
-                workOrder.WorkOrder.ExecutionId = GetNextExecutionId();
-                var result = await client.ExecuteAsync(workOrder);
-                Log.Information("Run: Execution Id: {Id} Result: {Result}", workOrder.WorkOrder.ExecutionId, result);
-                return result;
-            }
-
-            var tasks = new Task[settings.ExecutionCount];
-            for (var i = 0; i < tasks.Length; ++i) {
-                tasks[i] = Exec();
-            }
-
-            await Task.WhenAll(tasks);
-        } finally {
-            await app.StopAsync();
+        async Task<Rpc.WorkResult> Exec() {
+            var workOrder = GetServerWorkOrder(settings, config);
+            workOrder.WorkOrder.ExecutionId = GetNextExecutionId();
+            var result = await worker.Execute(workOrder.WorkOrder, default);
+            Log.Information("Run: Execution Id: {Id} Result: {Result}",
+                workOrder.WorkOrder.ExecutionId, result);
+            return result;
         }
+
+        var tasks = new Task[settings.ExecutionCount];
+        for (var i = 0; i < tasks.Length; ++i) {
+            tasks[i] = Exec();
+        }
+
+        await Task.WhenAll(tasks);
 
         return 0;
     }

--- a/Trell/IPC/Worker/TrellWorkerImpl.cs
+++ b/Trell/IPC/Worker/TrellWorkerImpl.cs
@@ -38,7 +38,7 @@ public class TrellWorkerImpl : Rpc.TrellWorker.TrellWorkerBase, IDisposable {
         throw new TrellUserException(error);
     }
 
-    public override async Task<Rpc.WorkResult> Execute(Rpc.WorkOrder request, ServerCallContext context) {
+    public override async Task<Rpc.WorkResult> Execute(Rpc.WorkOrder request, ServerCallContext _context) {
         Log.Information("In TrellWorker Execute");
         this.currentExecs.TryAdd(request, null);
 
@@ -113,7 +113,7 @@ public class TrellWorkerImpl : Rpc.TrellWorker.TrellWorkerBase, IDisposable {
         }
     }
 
-    public override async Task<Rpc.QueryWorkerDbResult> QueryWorkerDb(Rpc.QueryWorkerDbRequest request, ServerCallContext context) {
+    public override async Task<Rpc.QueryWorkerDbResult> QueryWorkerDb(Rpc.QueryWorkerDbRequest request, ServerCallContext _context) {
         if (this.extensionContainer.Storage == null) {
             // TODO: what to throw?
             throw new InvalidOperationException();
@@ -199,7 +199,7 @@ public class TrellWorkerImpl : Rpc.TrellWorker.TrellWorkerBase, IDisposable {
         }
     }
 
-    public override Task<Rpc.ListCurrentExecutionsResult> ListCurrentExecutions(Empty request, ServerCallContext context) {
+    public override Task<Rpc.ListCurrentExecutionsResult> ListCurrentExecutions(Empty request, ServerCallContext _context) {
         var current = new Rpc.ListCurrentExecutionsResult();
 
         foreach (var work in this.currentExecs.Keys) {
@@ -216,7 +216,7 @@ public class TrellWorkerImpl : Rpc.TrellWorker.TrellWorkerBase, IDisposable {
         return Task.FromResult(current);
     }
 
-    public override Task<Rpc.CancelWorkerExecutionsResult> CancelWorkerExecutions(Rpc.CancelWorkerExecutionsRequest request, ServerCallContext context) {
+    public override Task<Rpc.CancelWorkerExecutionsResult> CancelWorkerExecutions(Rpc.CancelWorkerExecutionsRequest request, ServerCallContext _context) {
         var r = new Rpc.CancelWorkerExecutionsResult();
         if (this.workerIdToWorkOrderToCts.TryGetValue(request.WorkerId, out var workAndCancellationTokenSourcePairs)) {
             foreach (var (work, cts) in workAndCancellationTokenSourcePairs) {


### PR DESCRIPTION
I know we'd discussed what would be necessary to make intra-process communication work with gRPC so that we could run a worker inside a server, but I found again when I was trying to debug a `trell run` that sticking everything into a single process makes things much simpler. This is a simpler version of previous attempts that just instantiates the `TrellWorkerImpl` and passes the `WorkOrder` to it directly.

I don't think this precludes running a worker in a server process unless you'd like that mechanism and this mechanism to be the same.