### PR TITLE
Run worker in server process when pool size is 0.

### DIFF
--- a/Trell/CliCommands/RunCommand.cs
+++ b/Trell/CliCommands/RunCommand.cs
@@ -83,6 +83,7 @@ public abstract class RunCommand<T> : AsyncCommand<T> where T : RunCommandSettin
         settings.Validate();
         App.BootstrapLogger(settings.LogLevel);
         var config = TrellConfig.LoadToml(settings.Config ?? "Trell.toml");
+        config.Worker.Pool.Size = 0;
         var args = context.Remaining.Raw.ToArray();
         using var app = App.InitServer(config, args);
         await app.StartAsync();

--- a/Trell/Collections/BoundedObjectPool.cs
+++ b/Trell/Collections/BoundedObjectPool.cs
@@ -9,7 +9,7 @@ namespace Trell.Collections;
 /// When [pending] > 0, gets the Lazy.Value of each unallocated object in a
 /// Task so that any long construction time happens before the object is needed.
 /// </remarks>
-sealed class BoundedObjectPool<K, V> : IDisposable
+sealed class BoundedObjectPool<K, V> : IDisposable, IObjectPool<K, V>
 where K : notnull {
     readonly int max, pending;
 

--- a/Trell/Collections/BoundedObjectPool.cs
+++ b/Trell/Collections/BoundedObjectPool.cs
@@ -47,7 +47,7 @@ where K : notnull {
     public int Count => this.allocated.Count;
     public int Pending => this.unallocated.Count;
 
-    public IEnumerable<WorkerHandle> Values => (IEnumerable<WorkerHandle>)this.allocated.Values;
+    public IEnumerable<V> Values => this.allocated.Values;
 
     public bool TryGet(K key, out V val) {
 #pragma warning disable CS8601 // Possible null reference assignment.

--- a/Trell/Collections/IObjectPool.cs
+++ b/Trell/Collections/IObjectPool.cs
@@ -1,0 +1,9 @@
+using Trell.IPC.Server;
+
+namespace Trell.Collections;
+
+interface IObjectPool<K, V> : IDisposable where K : notnull {
+    IEnumerable<V> Values { get; }
+
+    bool TryGet(K key, out V val);
+}

--- a/Trell/Collections/InfiniteSingletonObjectPool.cs
+++ b/Trell/Collections/InfiniteSingletonObjectPool.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Trell.IPC.Server;
+
+namespace Trell.Collections;
+
+sealed class InfiniteSingletonObjectPool<K, V> : IObjectPool<K, V> where K : notnull {
+    readonly V singleton;
+
+    public InfiniteSingletonObjectPool(V singleton) {
+        this.singleton = singleton;
+    }
+
+    public IEnumerable<V> Values => [this.singleton];
+
+    public bool TryGet(K key, out V val) {
+        val = this.singleton;
+        return true;
+    }
+
+    public void Dispose() {
+        if (this.singleton is IDisposable disposable) {
+            disposable.Dispose();
+        }
+    }
+}

--- a/Trell/IPC/Server/WorkerHandle.cs
+++ b/Trell/IPC/Server/WorkerHandle.cs
@@ -117,6 +117,15 @@ sealed class WorkerHandle {
         return handle;
     }
 
+    public static WorkerHandle InProcess(WorkerOptions opts) {
+        var process = Process.GetCurrentProcess();
+        var handle = new WorkerHandle(opts, process);
+        Log.Information("Worker {Id} running in current process ({Pid}).",
+            opts.WorkerAddress.WorkerId,
+            process.Id);
+        return handle;
+    }
+
     internal IDisposable Track(WorkOrder request) {
         this.executionsById.TryAdd(request.ExecutionId, new Execution(request.User.UserId, request.User.Data.ToDictionary(), request.ExecutionId));
 


### PR DESCRIPTION
An idea I wanted to try out. Still uses an inter-process communication mechanism to communicate between server and worker since I've never been able to figure out if there's any way to make the gRPC library we use handle not-remote procedure calls.

Maps worker to the server's Unix socket so the server can call the worker (itself) over that same socket.

`trell run` forces pool size to 0 for ease of debugging.

An alternative to #8; though we could use both if we desired. Needs to be merged after #9.