### PR TITLE
Run command streamlining

### DIFF
--- a/Trell.Engine/Utility/IO/TrellPath.cs
+++ b/Trell.Engine/Utility/IO/TrellPath.cs
@@ -85,7 +85,7 @@ public class TrellPath {
                     if (j == 0) {
                         return false;
                     }
-                    if (i == pathSegment.Length - 1) {
+                    if (j == pathSegment.Length - 1) {
                         return false;
                     }
                     if (j > 0 && pathSegment[j - 1] == '.') {

--- a/Trell.Test/Utility/IO/TrellPathTest.cs
+++ b/Trell.Test/Utility/IO/TrellPathTest.cs
@@ -30,4 +30,11 @@ public class TrellPathTest {
 
         Assert.True(TrellPath.TryParseRelative("foo.db", out path));
     }
+
+    [Fact]
+    public void TestRelativePathRegression() {
+        // Covers a regression where wrong iterator variable was used to determine if
+        // a '.' character in a path's segment was its last character or not.
+        Assert.True(TrellPath.TryParseRelative("x/y/2.0/z", out _));
+    }
 }

--- a/Trell/CliCommands/InitCommand.cs
+++ b/Trell/CliCommands/InitCommand.cs
@@ -23,7 +23,7 @@ public class InitCommandSettings : CommandSettings {
     [CommandOption("-d|--user-data-dir <directory>"), Description("Directory to use for Trell user/worker data.")]
     public string? UserDataDirectory { get; set; }
 
-    [CommandOption("-u|--username <username>"), Description("New username to initialize example worker for.")]
+    [CommandOption("-u|--user <username>"), Description("New username to initialize example worker for.")]
     public string? Username { get; set; }
 
     [CommandOption("-w|--worker-name <worker-name>"), Description("Name of new example worker to initialize.")]

--- a/Trell/CliCommands/RunCommand.cs
+++ b/Trell/CliCommands/RunCommand.cs
@@ -36,7 +36,7 @@ public class RunCommandSettings : CommandSettings {
     [CommandArgument(1, "<handler-fn>"), Description("Specifies which worker handler function to call: scheduled, fetch, or upload")]
     public Rpc.Function.ValueOneofCase HandlerFn { get; set; } = Rpc.Function.ValueOneofCase.None;
 
-    [CommandArgument(2, "[data-path]"), Description("Path to upload data or patch to fetch replay data")]
+    [CommandArgument(2, "[data-path]"), Description("Path to upload data or path to fetch replay data")]
     public string? UploadDataPath { get; set; }
 
     public override ValidationResult Validate() {

--- a/Trell/DirectoryHelper.cs
+++ b/Trell/DirectoryHelper.cs
@@ -44,10 +44,7 @@ static class DirectoryHelper {
         Directory.CreateDirectory(workerDataDir);
     }
 
-    internal static string? QualifyLocalPathOrReturnSame(string? path) {
-        if (string.IsNullOrWhiteSpace(path) || Path.IsPathFullyQualified(path)) {
-            return path;
-        }
-        return Path.GetFullPath(path, Directory.GetCurrentDirectory());
+    internal static string GetFullPath(string? path) {
+        return Path.GetFullPath(string.IsNullOrWhiteSpace(path) ? "." : path);
     }
 }

--- a/Trell/DirectoryHelper.cs
+++ b/Trell/DirectoryHelper.cs
@@ -43,4 +43,11 @@ static class DirectoryHelper {
         Directory.CreateDirectory(workerSrcPath);
         Directory.CreateDirectory(workerDataDir);
     }
+
+    internal static string? QualifyLocalPathOrReturnSame(string? path) {
+        if (string.IsNullOrWhiteSpace(path) || Path.IsPathFullyQualified(path)) {
+            return path;
+        }
+        return Path.GetFullPath(path, Directory.GetCurrentDirectory());
+    }
 }

--- a/Trell/Program.cs
+++ b/Trell/Program.cs
@@ -18,13 +18,18 @@ class Program {
         app.Configure(config => {
             config.SetApplicationName("trell");
             config.AddCommand<CliCommands.InitCommand>("init")
-                .WithDescription("Prepare directory for using trell, creating example config and worker.");
+                .WithDescription("Prepare directory for using trell, creating example config and worker.")
+                .WithExample("init");
 
             config.AddCommand<CliCommands.ServerCommand>("serve")
                 .WithDescription("Start trell as a server, accepting commands via gRPC")
-                .WithExample(new[] { "serve", "--config", "Trell.toml" });
+                .WithExample("serve");
 
-            config.AddCommand<CliCommands.RunCommand>("run");
+            config.AddCommand<CliCommands.RunCommand>("run")
+                .WithDescription("Runs a given worker to completion")
+                .WithExample("run", ".", "scheduled")
+                .WithExample("run", "local/test.js", "scheduled")
+                .WithExample("run", ".", "upload", "path/to/file.csv");
 
             // Used by server
             config.AddCommand<CliCommands.WorkerCommand>("worker")

--- a/Trell/Program.cs
+++ b/Trell/Program.cs
@@ -24,15 +24,7 @@ class Program {
                 .WithDescription("Start trell as a server, accepting commands via gRPC")
                 .WithExample(new[] { "serve", "--config", "Trell.toml" });
 
-            config.AddBranch<CliCommands.RunCommandSettings>("run", run => {
-                run.SetDescription("Run scripts, directories, or workers (by id).");
-                run.AddExample("run file worker.js --handler cron");
-                run.AddExample("run dir my-worker-dir --handler webhook");
-                run.AddExample("run worker-id worker-123 --handler upload");
-
-                run.AddCommand<CliCommands.RunWorkerIdCommand>("worker")
-                    .WithDescription("Runs the named worker code stored in the server's data");
-            });
+            config.AddCommand<CliCommands.RunCommand>("run");
 
             // Used by server
             config.AddCommand<CliCommands.WorkerCommand>("worker")


### PR DESCRIPTION
Changed run commands to work as follows:
`trell run <run-directory> <functions: scheduled | upload | fetch> <if upload: path for file to upload> [OPTIONS]`

Options now include `--shared-db-dir` and `--worker-db-dir`

Some paths you may specify won't work because parts of Trell are hard-coded to expect certain paths (see: Trell.Rpc.ToEngine, logic around line 119), and also because TrellPath can't handle certain characters in folder names, but otherwise this new configuration is set up to work with arbitrarily located files.