### PR TITLE
Removed the InternalsVisibleTo assembly attribute from TrellEngine

### DIFF
--- a/Trell.Engine/AssemblyInfo.cs
+++ b/Trell.Engine/AssemblyInfo.cs
@@ -12,7 +12,6 @@ using System.Runtime.InteropServices;
 // attribute to true on that type.
 
 [assembly: ComVisible(false)]
-[assembly: InternalsVisibleTo("Trell")]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM.
 

--- a/Trell.Engine/Utility/Assert.cs
+++ b/Trell.Engine/Utility/Assert.cs
@@ -3,17 +3,17 @@ using System.Runtime.CompilerServices;
 
 namespace Trell.Engine.Utility;
 
-static class Assert {
+public static class Assert {
     [DoesNotReturn]
     static internal void False() => throw new AssertionFailed("False.");
 
-    static internal void IsTrue(bool condition, [CallerArgumentExpression(nameof(condition))] string conditionExpression = "") {
+    static public void IsTrue(bool condition, [CallerArgumentExpression(nameof(condition))] string conditionExpression = "") {
         if (!condition) {
             throw new AssertionFailed($"The expression \"{conditionExpression}\" is false.");
         }
     }
 
-    static internal void NotNull([NotNull] object? o, [CallerArgumentExpression(nameof(o))] string conditionExpression = "") {
+    static public void NotNull([NotNull] object? o, [CallerArgumentExpression(nameof(o))] string conditionExpression = "") {
         if (o is null) {
             throw new AssertionFailed($"The expression \"{conditionExpression}\" is false.");
         }

--- a/Trell.Engine/Utility/Disposable.cs
+++ b/Trell.Engine/Utility/Disposable.cs
@@ -1,10 +1,10 @@
 namespace Trell.Engine.Utility;
 
-class Disposable : IDisposable, IAsyncDisposable {
+public class Disposable : IDisposable, IAsyncDisposable {
     int isDisposed;
     Action? action;
 
-    internal static Disposable FromAction(Action action) {
+    public static Disposable FromAction(Action action) {
         return new Disposable {
             action = action
         };

--- a/Trell.Engine/Utility/Extensions/ConcurrentQueueExtensions.cs
+++ b/Trell.Engine/Utility/Extensions/ConcurrentQueueExtensions.cs
@@ -2,8 +2,8 @@ using System.Collections.Concurrent;
 
 namespace Trell.Engine.Utility.Extensions;
 
-static class ConcurrentQueueExtensions {
-    internal static void EnqueueRange<T>(this ConcurrentQueue<T> @this, IEnumerable<T> range) {
+public static class ConcurrentQueueExtensions {
+    public static void EnqueueRange<T>(this ConcurrentQueue<T> @this, IEnumerable<T> range) {
         foreach (var item in range) {
             @this.Enqueue(item);
         }

--- a/Trell.Engine/Utility/Extensions/LinqExtensions.cs
+++ b/Trell.Engine/Utility/Extensions/LinqExtensions.cs
@@ -1,12 +1,12 @@
 namespace Trell.Engine.Utility.Extensions;
 
-static class LinqExtensions {
-    internal static void Deconstruct<K, V>(this IGrouping<K, V> @this, out K key, out IEnumerable<V> value) {
+public static class LinqExtensions {
+    public static void Deconstruct<K, V>(this IGrouping<K, V> @this, out K key, out IEnumerable<V> value) {
         key = @this.Key;
         value = @this;
     }
 
-    internal static IEnumerable<(int, T)> Indexed<T>(this IEnumerable<T> @this) {
+    public static IEnumerable<(int, T)> Indexed<T>(this IEnumerable<T> @this) {
         var i = 0;
         foreach (var item in @this) {
             yield return (i, item);

--- a/Trell.Engine/Utility/Extensions/SqliteExtensions.cs
+++ b/Trell.Engine/Utility/Extensions/SqliteExtensions.cs
@@ -3,8 +3,8 @@ using static SQLitePCL.raw;
 
 namespace Trell.Engine.Utility.Extensions;
 
-static class SqliteExtensions {
-    internal static void Interrupt(this SqliteConnection conn) {
+public static class SqliteExtensions {
+    public static void Interrupt(this SqliteConnection conn) {
         sqlite3_interrupt(conn.Handle);
     }
 }


### PR DESCRIPTION
Also made a handful of TrellEngine methods/classes public because Trell relies on them