### PR TITLE
Added manual workflow trigger to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Adding this trigger to the build.yml file would let us manually run the test workflow on Github on any remote branch. This would let us make sure our tests pass on Github, without needing to start a PR to merge into master.

Github documentation on the trigger:
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch

