### PR TITLE
Clean up path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,16 @@ USAGE:
     trell [OPTIONS] <COMMAND>
 
 EXAMPLES:
-    trell serve --config Trell.toml
-    trell run file worker.js --handler cron
-    trell run dir my-worker-dir --handler webhook
-    trell run worker-id worker-123 --handler upload
+    trell init
+    trell serve
+    trell run scheduled
+    trell run upload path/to/file.csv
 
 OPTIONS:
     -h, --help    Prints help information
 
 COMMANDS:
-    serve    Start trell as a server, accepting commands via gRPC
-    run      Run scripts, directories, or workers (by id)
+    init                Initialize directory with a new worker to get started with trell faster
+    serve               Start trell as a server, accepting commands via gRPC
+    run <handler-fn>    Runs a handler on the worker
 ```

--- a/Trell.Engine/Extensibility/Interfaces/IStorageProvider.cs
+++ b/Trell.Engine/Extensibility/Interfaces/IStorageProvider.cs
@@ -6,12 +6,12 @@ namespace Trell.Engine.Extensibility.Interfaces;
 public interface IStorageProvider {
     int MaxDatabasePageCount { get; }
 
-    bool TryResolvePath(
+    bool TryResolveTrellPath(
         string path,
         [NotNullWhen(true)] out AbsolutePath resolvedPath,
         [NotNullWhen(false)] out TrellError? error);
 
-    bool TryWithRoot(
+    bool TryScopeToSubdirectory(
         string path,
         [NotNullWhen(true)] out IStorageProvider? newStorage,
         [NotNullWhen(false)] out TrellError? error);

--- a/Trell.Engine/Extensibility/SQLiteApi.cs
+++ b/Trell.Engine/Extensibility/SQLiteApi.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json;
 using Trell.Engine.ClearScriptWrappers;
 using Trell.Engine.Extensibility.Interfaces;
 using Trell.Engine.Utility.Concurrent;
@@ -83,6 +84,7 @@ namespace Trell.Engine.Extensibility {
             SqliteConnector SharedConnector { get; }
             SqliteConnector? WorkerConnector { get; }
             IReadOnlyCollection<string> AllowedSharedDbs { get; }
+            readonly static Regex ValidDbNamePattern = new (@"\A(shared\/)?[a-z0-9_]+\z", RegexOptions.ExplicitCapture | RegexOptions.Compiled);
 
             public SQLite(
                 SqliteConnector sharedConnector,
@@ -109,8 +111,19 @@ namespace Trell.Engine.Extensibility {
             public async Task<SQLiteConn> Open(dynamic? options = null) {
                 var context = this.Context.Value!;
                 context.CancellationToken.ThrowIfCancellationRequested();
-                var dbName = options?.dbname as string ?? "default";
-                var isSharedDb = dbName.StartsWith("shared/");
+
+                var dbName = "default";
+                var isSharedDb = false;
+
+                if (options?.dbname is string customDbName) {
+                    if (!ValidDbNamePattern.IsMatch(customDbName)) {
+                        throw new TrellUserException(
+                            new TrellError(TrellErrorCode.INVALID_DB_NAME,
+                                $"\"{dbName}\" is not a valid db name. Expected a name matching {ValidDbNamePattern}"));
+                    }
+                    dbName = customDbName;
+                    isSharedDb = dbName.StartsWith("shared/");
+                }
 
                 if (isSharedDb && !this.AllowedSharedDbs.Contains(dbName)) {
                     throw new TrellUserException(

--- a/Trell.Engine/Extensibility/SqliteConnector.cs
+++ b/Trell.Engine/Extensibility/SqliteConnector.cs
@@ -12,7 +12,7 @@ public class SqliteConnector(IStorageProvider storage) {
     public async Task<SqliteConnection> Open(string dbName, SqliteConnectionOptions options) {
         var dbfilename = dbName + ".db";
 
-        if (!storage.TryResolvePath(dbfilename, out var resolvedPath, out var err)) {
+        if (!storage.TryResolveTrellPath(dbfilename, out var resolvedPath, out var err)) {
             throw new TrellUserException(err);
         }
 

--- a/Trell.Engine/Extensibility/TrellError.cs
+++ b/Trell.Engine/Extensibility/TrellError.cs
@@ -31,4 +31,5 @@ public enum TrellErrorCode {
     ENTRY_POINT_NOT_DEFINED,
     TIMEOUT,
     UNAUTHORIZED_DATABASE_ACCESS,
+    INVALID_DB_NAME
 }

--- a/Trell.Engine/Utility/IO/TrellPath.cs
+++ b/Trell.Engine/Utility/IO/TrellPath.cs
@@ -9,24 +9,20 @@ public class TrellPath {
     //        | RegexOptions.Compiled,
     //        TimeSpan.FromMilliseconds(100));
 
-    readonly static HashSet<char> AllowedPathCharacter;
-    readonly static HashSet<char> ValidFolderNameCharacters = [];
+    readonly static HashSet<char> AllowedPathCharacter = new HashSet<char>();
     const int MAX_PATH_LENGTH = 4 * 1024;
-
     internal readonly static TrellPath WorkerJs;
 
     static TrellPath() {
         for (int i = 'a'; i <= 'z'; i++) {
-            ValidFolderNameCharacters.Add((char)i);
+            AllowedPathCharacter.Add((char)i);
         }
 
         for (int i = '0'; i <= '9'; i++) {
-            ValidFolderNameCharacters.Add((char)i);
+            AllowedPathCharacter.Add((char)i);
         }
 
-        ValidFolderNameCharacters.Add('_');
-
-        AllowedPathCharacter = new(ValidFolderNameCharacters);
+        AllowedPathCharacter.Add('_');
         AllowedPathCharacter.Add('/');
         AllowedPathCharacter.Add('.');
 
@@ -41,15 +37,13 @@ public class TrellPath {
         this.PathSegments = pathSegments;
     }
 
-    public override string ToString() => string.Join('/', this.PathSegments);
-
-    static bool IsSpecialPathCharacter(char c) =>
-        c == '.' || c == '/';
-
     /// <summary>
     /// Parses a relative path without traversal.
     /// </summary>
-    public static bool TryParseRelative(string path, [NotNullWhen(true)] out TrellPath? trellPath) {
+    public static bool TryParseRelative(
+        string path,
+        [NotNullWhen(true)] out TrellPath? trellPath
+    ) {
         trellPath = default;
         if (string.IsNullOrWhiteSpace(path) || path.Length > MAX_PATH_LENGTH) {
             return false;
@@ -58,7 +52,7 @@ public class TrellPath {
         path = path.ToLowerInvariant();
 
         for (int i = 0; i < path.Length; i++) {
-            if (i == 0 && IsSpecialPathCharacter(path[i])) {
+            if (i == 0 && path[i] == '/') {
                 return false;
             }
             if (!AllowedPathCharacter.Contains(path[i])) {
@@ -82,12 +76,6 @@ public class TrellPath {
                 var c = pathSegment[j];
                 var isDot = c == '.';
                 if (isDot) {
-                    if (j == 0) {
-                        return false;
-                    }
-                    if (j == pathSegment.Length - 1) {
-                        return false;
-                    }
                     if (j > 0 && pathSegment[j - 1] == '.') {
                         return false;
                     }
@@ -104,17 +92,5 @@ public class TrellPath {
         return true;
     }
 
-    public static bool IsValidNameForFolder(string folderName) {
-        if (string.IsNullOrWhiteSpace(folderName)) {
-            return false;
-        }
-
-        for (int i = 0; i < folderName.Length; i++) {
-            if (!ValidFolderNameCharacters.Contains(folderName[i])) {
-                return false;
-            }
-        }
-
-        return true;
-    }
+    public override string ToString() => string.Join('/', this.PathSegments);
 }

--- a/Trell.Engine/Utility/IO/TrellPath.cs
+++ b/Trell.Engine/Utility/IO/TrellPath.cs
@@ -79,6 +79,10 @@ public class TrellPath {
                     if (j > 0 && pathSegment[j - 1] == '.') {
                         return false;
                     }
+                    if ((j == 0 || j == pathSegment.Length - 1)
+                        && pathSegment.Length > 1) {
+                        return false;
+                    }
                 }
             }
         }

--- a/Trell.Test/Extensibility/SQLiteTest.cs
+++ b/Trell.Test/Extensibility/SQLiteTest.cs
@@ -119,7 +119,7 @@ public class SQLiteTest(DatabaseFixture dbFixture) : IClassFixture<DatabaseFixtu
     sealed class FakeProvider(int maxDatabasePageCount, TryResolvePathValues tryResolvePathValues, TryWithRootValues tryWithRootValues) : IStorageProvider {
         public int MaxDatabasePageCount => maxDatabasePageCount;
 
-        public bool TryResolvePath(string path, [NotNullWhen(true)] out AbsolutePath resolvedPath, [NotNullWhen(false)] out TrellError? error) {
+        public bool TryResolveTrellPath(string path, [NotNullWhen(true)] out AbsolutePath resolvedPath, [NotNullWhen(false)] out TrellError? error) {
             string resolved = tryResolvePathValues.ResolvedPathValue;
             if (!resolved.EndsWith(Path.DirectorySeparatorChar)) {
                 resolved += Path.DirectorySeparatorChar;
@@ -129,7 +129,7 @@ public class SQLiteTest(DatabaseFixture dbFixture) : IClassFixture<DatabaseFixtu
             return tryResolvePathValues.ReturnValue;
         }
 
-        public bool TryWithRoot(string path, [NotNullWhen(true)] out IStorageProvider? newStorage, [NotNullWhen(false)] out TrellError? error) {
+        public bool TryScopeToSubdirectory(string path, [NotNullWhen(true)] out IStorageProvider? newStorage, [NotNullWhen(false)] out TrellError? error) {
             newStorage = tryWithRootValues.NewStorageValue;
             error = tryWithRootValues.ErrorValue;
             return tryWithRootValues.ReturnValue;

--- a/Trell.Test/Utility/IO/TrellPathTest.cs
+++ b/Trell.Test/Utility/IO/TrellPathTest.cs
@@ -9,10 +9,10 @@ public class TrellPathTest {
         Assert.False(TrellPath.TryParseRelative("//bar", out _));
         Assert.False(TrellPath.TryParseRelative("bar//", out _));
         Assert.False(TrellPath.TryParseRelative("../bar/", out _));
-        Assert.False(TrellPath.TryParseRelative("./bar", out _));
         Assert.False(TrellPath.TryParseRelative("bar/../foo", out _));
         Assert.False(TrellPath.TryParseRelative("bar/.foo", out _));
         Assert.False(TrellPath.TryParseRelative(".foo", out _));
+        Assert.False(TrellPath.TryParseRelative("foo.", out _));
         Assert.False(TrellPath.TryParseRelative("bar/Sentence Folder Guy/foo", out _));
         Assert.False(TrellPath.TryParseRelative("bar\\WindowsMan\\foo", out _));
         Assert.False(TrellPath.TryParseRelative(" WhiteSpaceMaxxer ", out _));
@@ -23,6 +23,7 @@ public class TrellPathTest {
         Assert.True(TrellPath.TryParseRelative("CAPSLOCK/1connoisseur", out var path));
         Assert.Equal("capslock", path.PathSegments[0]);
         Assert.Equal("1connoisseur", path.PathSegments[1]);
+        Assert.True(TrellPath.TryParseRelative("./bar", out _));
 
         Assert.True(TrellPath.TryParseRelative("foo/bar/", out path));
         Assert.Equal("foo", path.PathSegments[0]);

--- a/Trell/CliCommands/InitCommand.cs
+++ b/Trell/CliCommands/InitCommand.cs
@@ -107,9 +107,9 @@ class InitCommand : AsyncCommand<InitCommandSettings> {
         AnsiConsole.WriteLine($"""
             Trell worker created in {currentDir}.
             You can run worker commands with:
-                trell run . scheduled
-                trell run . upload example.csv
-                trell run . fetch request.json
+                trell run scheduled
+                trell run upload example.csv
+                trell run fetch request.json
             """
         );
         return 0;

--- a/Trell/CliCommands/RunCommand.cs
+++ b/Trell/CliCommands/RunCommand.cs
@@ -15,33 +15,18 @@ using Trell.IPC.Server;
 namespace Trell.CliCommands;
 
 public class RunCommandSettings : CommandSettings {
-    [CommandArgument(0, "<worker-file-or-dir>"), Description("Either a worker's file path or a directory containing a worker.js to run")]
-    public required string WorkerPath { get; set; }
-
-    [CommandArgument(1, "<handler-fn>"), Description("Specifies which worker handler function to call: scheduled, fetch, or upload")]
+    [CommandArgument(0, "<handler-fn>"), Description("Worker handler function to call: scheduled, fetch, or upload")]
     public Rpc.Function.ValueOneofCase HandlerFn { get; set; } = Rpc.Function.ValueOneofCase.None;
 
-    [CommandArgument(2, "[data-file]"), Description("File path for data to upload or to fetch replay data")]
+    [CommandArgument(1, "[data-file]"), Description("File path for data to upload")]
     public string? DataFile { get; set; }
 
     public override ValidationResult Validate() {
-        if (string.IsNullOrWhiteSpace(this.WorkerPath)) {
-            return ValidationResult.Error("A path for a worker file or directory needs to be specified");
-        }
-        var runDir = DirectoryHelper.GetFullPath(this.WorkerPath);
-        if (File.Exists(runDir)) {
-            // WorkerPath must either be the current directory or exist under our current directory if it's a file path
-            if (Path.GetRelativePath(Directory.GetCurrentDirectory(), runDir) == runDir) {
-                return ValidationResult.Error("'run' may only be called on files that exist in or under the current working directory");
-            }
-        } else if (!Directory.Exists(runDir)) {
-            return ValidationResult.Error("'run' can only be called on a directory or file that exists");
-        }
         if (this.HandlerFn == Rpc.Function.ValueOneofCase.None) {
             return ValidationResult.Error("A worker handler function must be passed as an argument");
         } else if (this.HandlerFn == Rpc.Function.ValueOneofCase.Upload) {
-            var filePath = DirectoryHelper.GetFullPath(this.DataFile);
-            if (!File.Exists(filePath)) {
+            if (string.IsNullOrWhiteSpace(this.DataFile)
+                || !File.Exists(Path.GetFullPath(this.DataFile))) {
                 return ValidationResult.Error("Uploading requires a valid path for an existing file be passed as an argument");
             }
         }
@@ -56,33 +41,30 @@ public class RunCommand : AsyncCommand<RunCommandSettings> {
     Rpc.ServerWorkOrder GetServerWorkOrder(RunCommandSettings settings, TrellConfig config) {
         // Makes all paths relative to worker root and sanitizes paths for TrellPath's use.
         var rootDir = Path.GetFullPath(config.Storage.Path);
-        string Sanitize(string s) {
-            if (Path.IsPathFullyQualified(s)) {
-                s = Path.GetRelativePath(rootDir, s);
-            }
-            return s.Replace('\\', '/');
-        }
 
-        var dataPath = Sanitize(config.Storage.DataPath);
+        var dataPath = config.Storage.DataPath;
 
-        var sharedDbDir = Path.GetFullPath(Path.Combine(dataPath, "shared"), rootDir);
-        var sharedDbExists = Directory.Exists(sharedDbDir);
+        var relativeSharedDbDir = Path.Combine(dataPath, "shared");
         List<string> sharedDbs = [];
-        if (sharedDbExists) {
-            foreach (var db in Directory.EnumerateFiles(sharedDbDir, "*.db", new EnumerationOptions {
-                IgnoreInaccessible = true,
-            })) {
-                sharedDbs.Add("shared/" + Path.GetFileNameWithoutExtension(db));
+
+        { // @FIXME - Find a better place to put this
+            var sharedDbDir = Path.GetFullPath(relativeSharedDbDir, rootDir);
+            var sharedDbExists = Directory.Exists(sharedDbDir);
+            if (sharedDbExists) {
+                foreach (var db in Directory.EnumerateFiles(sharedDbDir, "*.db", new EnumerationOptions {
+                    IgnoreInaccessible = true,
+                })) {
+                    sharedDbs.Add("shared/" + Path.GetFileNameWithoutExtension(db));
+                }
             }
         }
-        sharedDbDir = Sanitize(sharedDbDir);
 
-        var codePath = Sanitize(rootDir);
+        var codePath = config.Storage.Path;
+        var fileName = "worker.js";
 
-        var workerPath = DirectoryHelper.GetFullPath(settings.WorkerPath);
-        var fileName = Sanitize(File.Exists(workerPath) ? workerPath : Path.GetFullPath("worker.js", workerPath));
-
-        var dataFilePath = DirectoryHelper.GetFullPath(settings.DataFile);
+        if (settings.DataFile is not null) {
+            settings.DataFile = Path.GetFullPath(settings.DataFile);
+        }
 
         return new Rpc.ServerWorkOrder {
             WorkOrder = new() {
@@ -97,7 +79,7 @@ public class RunCommand : AsyncCommand<RunCommandSettings> {
                     },
                 },
                 Workload = new() {
-                    Function = GetFunction(settings.HandlerFn, dataFilePath),
+                    Function = GetFunction(settings.HandlerFn, settings.DataFile),
                     Data = new() {
                         Text = JsonSerializer.Serialize(new { timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString() }),
                     },
@@ -108,7 +90,7 @@ public class RunCommand : AsyncCommand<RunCommandSettings> {
                 SharedDatabases = {
                     sharedDbs,
                 },
-                SharedDatabasesPath = sharedDbDir,
+                SharedDatabasesPath = relativeSharedDbDir,
             },
         };
     }
@@ -139,18 +121,17 @@ public class RunCommand : AsyncCommand<RunCommandSettings> {
                     Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
                 },
             },
-            Rpc.Function.ValueOneofCase.Webhook => new() {
-                // @TODO: Allow passing this from a HAR file. (Right click a request in Chrome, save as .har).
-                Webhook = new() {
-                    Url = "http://localhost:9305/webhooks/1/pay",
-                    Method = "POST",
-                    Headers = {
-                        { "Accept", "text/plain" },
-                        { "Accept-Language", "en/US" },
-                    },
-                    Body = ByteString.CopyFromUtf8("Update your payment records."),
-                },
-            },
+            Rpc.Function.ValueOneofCase.Webhook =>
+                //Webhook = new() {
+                //    Url = "http://localhost:9305/webhooks/1/pay",
+                //    Method = "POST",
+                //    Headers = {
+                //            { "Accept", "text/plain" },
+                //            { "Accept-Language", "en/US" },
+                //        },
+                //    Body = ByteString.CopyFromUtf8("Update your payment records."),
+                //},
+                throw new NotImplementedException("Running webhook payloads from the CLI is not implemented yet."),
             Rpc.Function.ValueOneofCase.Upload => new() {
                 Upload = GenerateUpload(uploadDataPath),
             },
@@ -167,7 +148,6 @@ public class RunCommand : AsyncCommand<RunCommandSettings> {
         settings.Validate();
         App.BootstrapLogger(null);
         var config = TrellConfig.LoadToml("Trell.toml");
-        config.Storage.Path = ".";
 
         var extensionContainer = TrellSetup.ExtensionContainer(config);
         var runtimeWrapper = new RuntimeWrapper(extensionContainer, config.ToRuntimeConfig());

--- a/Trell/DirectoryHelper.cs
+++ b/Trell/DirectoryHelper.cs
@@ -43,8 +43,4 @@ static class DirectoryHelper {
         Directory.CreateDirectory(workerSrcPath);
         Directory.CreateDirectory(workerDataDir);
     }
-
-    internal static string GetFullPath(string? path) {
-        return Path.GetFullPath(string.IsNullOrWhiteSpace(path) ? "." : path);
-    }
 }

--- a/Trell/IPC/Server/TrellServer.cs
+++ b/Trell/IPC/Server/TrellServer.cs
@@ -91,7 +91,7 @@ public class TrellServer : Rpc.TrellServer.TrellServerBase {
             }
         }
 
-        if (!this.extensionContainer.Storage!.TryResolvePath($"users/{request.User.UserId}/workers/{request.WorkerId}", out var dir, out var error)) {
+        if (!this.extensionContainer.Storage!.TryResolveTrellPath($"users/{request.User.UserId}/workers/{request.WorkerId}", out var dir, out var error)) {
             throw new TrellUserException(error);
         }
 

--- a/Trell/IPC/Worker/TrellWorkerCore.cs
+++ b/Trell/IPC/Worker/TrellWorkerCore.cs
@@ -8,7 +8,6 @@ using System.Data;
 using Trell.Engine.ClearScriptWrappers;
 using Trell.Engine.Extensibility;
 using Trell.Engine.Extensibility.Interfaces;
-using Trell.Rpc;
 using static Trell.Rpc.ToEngine;
 
 namespace Trell.IPC.Worker;
@@ -31,7 +30,7 @@ sealed class TrellWorkerCore : IDisposable, IWorkerClient {
     }
 
     SqliteConnector Connector(IStorageProvider storage, string path) {
-        if (storage.TryWithRoot(path, out var dbStorage, out var error)) {
+        if (storage.TryScopeToSubdirectory(path, out var dbStorage, out var error)) {
             return new SqliteConnector(dbStorage);
         }
 

--- a/Trell/LocalFolderStorage.cs
+++ b/Trell/LocalFolderStorage.cs
@@ -7,8 +7,7 @@ namespace Trell;
 
 public class LocalFolderStorage : IStorageProvider {
     public int MaxDatabasePageCount { get; }
-
-    public DirectoryInfo RootDirectory { get; }
+    public string RootDirectory { get; }
 
     public LocalFolderStorage(AbsolutePath rootPath, int maxDatabasePageCount) {
         var d = new DirectoryInfo(rootPath);
@@ -18,11 +17,11 @@ public class LocalFolderStorage : IStorageProvider {
                 throw new ArgumentException("Directory must exist and could not be created.");
             }
         }
-        this.RootDirectory = d;
+        this.RootDirectory = d.FullName;
         this.MaxDatabasePageCount = maxDatabasePageCount;
     }
 
-    public bool TryResolvePath(
+    public bool TryResolveTrellPath(
         string path,
         [NotNullWhen(true)] out AbsolutePath resolvedPath,
         [NotNullWhen(false)] out TrellError? error
@@ -30,31 +29,30 @@ public class LocalFolderStorage : IStorageProvider {
         resolvedPath = default;
         error = null;
 
-        if (path == ".") {
-            resolvedPath = new AbsolutePath(this.RootDirectory.FullName);
-            return true;
+        if (Path.IsPathFullyQualified(path)) {
+            error = new TrellError(TrellErrorCode.INVALID_PATH, path);
+            return false;
         }
 
         if (!TrellPath.TryParseRelative(path, out var trellPath)) {
             error = new TrellError(TrellErrorCode.INVALID_PATH, path);
             return false;
         }
+        var relPath = string.Join(Path.DirectorySeparatorChar, trellPath.PathSegments);
+        resolvedPath = new AbsolutePath(Path.Join(this.RootDirectory, relPath));
 
-        var relPath = string.Join(Path.AltDirectorySeparatorChar, trellPath.PathSegments);
-        resolvedPath = new AbsolutePath(Path.Join(this.RootDirectory.FullName, relPath));
         return true;
     }
 
-    public bool TryWithRoot(string path, [NotNullWhen(true)] out IStorageProvider? newStorage, [NotNullWhen(false)] out TrellError? error) {
+    public bool TryScopeToSubdirectory(
+        string path,
+        [NotNullWhen(true)] out IStorageProvider? newStorage,
+        [NotNullWhen(false)] out TrellError? error
+    ) {
         newStorage = null;
         error = null;
 
-        if (TryResolvePath(path, out var resolvedPath, out var resolveError)) {
-            if (Directory.Exists(resolvedPath)) {
-                newStorage = new LocalFolderStorage(resolvedPath, this.MaxDatabasePageCount);
-                return true;
-            }
-
+        if (TryResolveTrellPath(path, out var resolvedPath, out var resolveError)) {
             if (File.Exists(resolvedPath)) {
                 error = new TrellError(TrellErrorCode.PERMISSION_ERROR, "Path points to existing non-directory file");
                 return false;

--- a/Trell/Program.cs
+++ b/Trell/Program.cs
@@ -26,10 +26,9 @@ class Program {
                 .WithExample("serve");
 
             config.AddCommand<CliCommands.RunCommand>("run")
-                .WithDescription("Runs a given worker to completion")
-                .WithExample("run", ".", "scheduled")
-                .WithExample("run", "local/test.js", "scheduled")
-                .WithExample("run", ".", "upload", "path/to/file.csv");
+                .WithDescription("Run a handler on the worker")
+                .WithExample("run", "scheduled")
+                .WithExample("run", "upload", "path/to/file.csv");
 
             // Used by server
             config.AddCommand<CliCommands.WorkerCommand>("worker")

--- a/Trell/Rpc/ToEngine.cs
+++ b/Trell/Rpc/ToEngine.cs
@@ -118,7 +118,7 @@ static class ToEngine {
             string.IsNullOrEmpty(request.Workload.CodePath)
               ? $"users/{request.User.UserId}/workers/{request.Workload.WorkerId}/src/"
               : request.Workload.CodePath;
-        if (!storage.TryResolvePath(path, out dir, out var error)) {
+        if (!storage.TryResolveTrellPath(path, out dir, out var error)) {
             throw new TrellUserException(error);
         }
 

--- a/Trell/TrellConfig.cs
+++ b/Trell/TrellConfig.cs
@@ -80,7 +80,7 @@ public partial record TrellConfig : IConfigurationProvider {
     public record LoggerConfig : ExtensionConfig;
 
     public record StorageConfig {
-        public AbsolutePath Path { get; set; } = "/Temp/TrellUserData";
+        public string Path { get; set; } = ".";
         public string DataPath { get; set; } = "data/";
         public int MaxDatabasePageCount { get; set; } = 1024;
     }


### PR DESCRIPTION
Various small things in this PR:

- Clean up Path handling
   - TrellPath was initially just made to validate db args, but that confused matters when we built on it more. Now that db name validation is done where it is needed (the sqlite code), and TrellPath is more flexible.
   - Don't try to resolve absolute paths (that doesn't make sense)
- Remove the ability to run a file for now.
  - We can add it back in some way later, but first we need to figure out the entry points. (E.g., is your test/foo.js file going to have a 'scheduled' function? That wouldn't really make sense in my opinion.)
  - Dropping the directory argument lines us up a little more with the `dotnet` cli, which seems well thought out
- Update readme
- Improve some function names

