### PR TITLE
Log Errors with pretty stacktrace.

### DIFF
--- a/Trell.Engine/RuntimeApis/BrowserApi.cs
+++ b/Trell.Engine/RuntimeApis/BrowserApi.cs
@@ -194,6 +194,8 @@ namespace Trell.Engine.RuntimeApis {
                             parts.push("undefined");
                         } else if (arg === null) {
                             parts.push("null");
+                        } else if (arg instanceof Error) {
+                            parts.push(arg.stack);
                         } else {
                             let s = arg?.toString();
                             parts.push(s);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1bdc5cea-3faa-4390-b72c-44f9f5f95306)

Path is fixed by https://github.com/xledger/trell/pull/6