### PR TITLE
Made BoundedObjectPool test less likely to fail

### DIFF
--- a/Trell.Test/Collections/BoundedObjectPoolTest.cs
+++ b/Trell.Test/Collections/BoundedObjectPoolTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -46,7 +47,7 @@ public class BoundedObjectPoolTest {
         const int MAX = 3;
         int currIdCtr = 27;
         using var pool = new BoundedObjectPool<int, int>(() => ++currIdCtr, MAX);
-
+        
         var storedValues = new Dictionary<int, int>();
         for (int i = 0; i < MAX; i++) {
             pool.TryGet(i, out int x);
@@ -66,7 +67,13 @@ public class BoundedObjectPoolTest {
     }
 
     [Fact]
-    public async Task TestPoolPreInitializesObjectsInPendingCollection() {
+    public void TestPoolPreInitializesObjectsInPendingCollection() {
+        // All pending behavior is asynchronous so we have to use this BlockingCollection to block
+        // the thread until we get expected results.
+        // It also acts as a timeout so the test nevers hangs indefinitely -- if the collection waits too
+        // long on an expected result, its given CancellationToken will stop the test with an exception.
+        var blocker = new BlockingCollection<int>();
+
         const int MAX = 3;
         const int PENDING = 4;
         int currIdCtr = 600;
@@ -74,82 +81,43 @@ public class BoundedObjectPoolTest {
         using var pool = new BoundedObjectPool<int, int>(
             () => {
                 Interlocked.Increment(ref initializationCtr);
-                return ++currIdCtr;
+                var id = ++currIdCtr;
+                blocker.Add(id);
+                return id;
             },
             MAX,
             PENDING
         );
 
-        // All pending behavior is asynchronous so we have to ask threads to sleep
-        // for a bit, otherwise we might fail a test because of a race.
-        const int TIMEOUT = 10000;  // 10 seconds
-        const int SHORT_WAIT = 100; // 0.1 seconds
-
         // Makes sure pending pre-initializes objects before we ever call TryGet, but
         // does not pre-initialize more objects than the max.
-        var taskRace = await Task.WhenAny(
-            Task.Run(() => {
-                while (initializationCtr < MAX) {
-                    Thread.Sleep(SHORT_WAIT);
-                }
-                return true;
-            }),
-            Task.Run(() => {
-                Thread.Sleep(TIMEOUT);
-                return false;
-            })
-        );
-        if (!taskRace.Result) {
-            throw new Exception("Test timed out");
+        for (int i = 0; i < MAX; i++) {
+            blocker.Take(new CancellationTokenSource(5000).Token);
         }
+        Assert.Equal(MAX, initializationCtr);
         Assert.True(pool.Pending <= MAX);
 
         // Testing that pre-initialization does not happen again until we return something to the pool
         for (int i = 0; i < MAX; i++) {
             pool.TryGet(i, out _);
         }
-        taskRace = await Task.WhenAny(
-            Task.Run(() => {
-                Thread.Sleep(TIMEOUT);
-                return true;
-            }),
-            Task.Run(() => {
-                while (initializationCtr == MAX) {
-                    Thread.Sleep(SHORT_WAIT);
-                }
-                return false;
-            })
-        );
-        if (!taskRace.Result) {
-            throw new Exception("Pre-initialization happened when it should not have");
-        }
+        Assert.Throws<OperationCanceledException>(() => blocker.Take(new CancellationTokenSource(2000).Token));
         Assert.Equal(MAX, initializationCtr);
 
         pool.TryRemove(0, out _);
-        taskRace = await Task.WhenAny(
-            Task.Run(() => {
-                while (initializationCtr == MAX) {
-                    Thread.Sleep(SHORT_WAIT);
-                }
-                return true;
-            }),
-            Task.Run(() => {
-                Thread.Sleep(TIMEOUT);
-                return false;
-            })
-        );
-        if (!taskRace.Result) {
-            throw new Exception("Test timed out");
-        }
+        blocker.Take(new CancellationTokenSource(5000).Token);
         Assert.Equal(MAX + 1, initializationCtr);
 
+        blocker = [];
         initializationCtr = 0;
         const int MAX_2 = 4;
         const int PENDING_2 = 2;
         using var pool2 = new BoundedObjectPool<int, int>(
             () => {
                 Interlocked.Increment(ref initializationCtr);
-                return ++currIdCtr;
+                var id = ++currIdCtr;
+                blocker.Add(id);
+                return id;
             },
             MAX_2,
             PENDING_2
@@ -157,21 +125,10 @@ public class BoundedObjectPoolTest {
 
         // If our pending count is less than our max, the number of pre-initialized
         // objects should not exceed the original pending count
-        taskRace = await Task.WhenAny(
-            Task.Run(() => {
-                while (initializationCtr < PENDING_2) {
-                    Thread.Sleep(SHORT_WAIT);
-                }
-                return true;
-            }),
-            Task.Run(() => {
-                Thread.Sleep(TIMEOUT);
-                return false;
-            })
-        );
-        if (!taskRace.Result) {
-            throw new Exception("Test timed out");
+        for (int i = 0; i < PENDING_2; i++) {
+            blocker.Take(new CancellationTokenSource(5000).Token);
         }
+        Assert.Throws<OperationCanceledException>(() => blocker.Take(new CancellationTokenSource(2000).Token));
         Assert.Equal(PENDING_2, initializationCtr);
     }
 }


### PR DESCRIPTION
The test that covered the "pending" object logic in BoundedObjectPool should be less likely to fail now. ~~The test is a lot less readable now, though, and I wonder if a better solution would have been to just increase the amount of time we waited in Thread.Sleep().~~