### PR TITLE
Removing possibly outdated code from TrellServer.cs

### DIFF
--- a/Trell/IPC/Server/TrellServer.cs
+++ b/Trell/IPC/Server/TrellServer.cs
@@ -115,15 +115,4 @@ public class TrellServer : Rpc.TrellServer.TrellServerBase {
         Serilog.Log.Information("Worker {Id} is ready.", request.WorkerId);
         return Task.FromResult(MessageConstants.Empty);
     }
-
-    /// <summary>
-    /// Called from the worker (on a user's behalf) to log.
-    /// </summary>
-    /// <param name="request"></param>
-    /// <param name="context"></param>
-    /// <returns></returns>
-    /// <exception cref="RpcException"></exception>
-    public override Task<Empty> Log(LogRequest request, ServerCallContext context) {
-        throw new NotImplementedException();
-    }
 }

--- a/Trell/IPC/Server/TrellServer.cs
+++ b/Trell/IPC/Server/TrellServer.cs
@@ -125,28 +125,5 @@ public class TrellServer : Rpc.TrellServer.TrellServerBase {
     /// <exception cref="RpcException"></exception>
     public override Task<Empty> Log(LogRequest request, ServerCallContext context) {
         throw new NotImplementedException();
-
-        //if (extensionContainer.Logger is not ITrellLogger logger) {
-        //    return Task.FromResult(MessageConstants.Empty);
-        //}
-
-        //var trellLogLevel = request.LogLevel switch {
-        //    LogLevel.Error => TrellLogLevel.Error,
-        //    LogLevel.Warning => TrellLogLevel.Warn,
-        //    _ => TrellLogLevel.Info,
-        //};
-
-        //if (!executionContextById.TryGetValue(request.ExecutionId, out var ctx)) {
-        //    var metadata = new Metadata {
-        //        { "ExecutionId", request.ExecutionId }
-        //    };
-        //    throw new RpcException(
-        //        new Status(StatusCode.InvalidArgument, "ExecutionId does not exist"),
-        //        metadata);
-        //}
-
-        //logger.Log(ctx, trellLogLevel, request.Message);
-
-        //return Task.FromResult(MessageConstants.Empty);
     }
 }

--- a/Trell/Protos/TrellServer.proto
+++ b/Trell/Protos/TrellServer.proto
@@ -31,9 +31,6 @@ service TrellServer {
 
   // -------------------- START INTERNAL API -----------------------------
 
-  // Called from the worker (on a user's behalf) to log.
-  rpc Log(LogRequest) returns (google.protobuf.Empty);
-
   // Called from the worker to let server know it is ready to work.
   rpc NotifyWorkerReady(WorkerReady) returns (google.protobuf.Empty);
 


### PR DESCRIPTION
Following a conversation with Matthew during recent Trell cleanup, there was one notable section of commented-out code which we aren't sure is still relevant, so its removal is its own PR

EDIT: the purpose of the entire method was in question, so this PR changed to evaluate it wholistically