### PR TITLE
Updated ClearScript to v7.5.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,10 +4,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Grpc.AspNetCore" Version="2.67.0" />
-    <PackageVersion Include="Microsoft.ClearScript.V8" Version="7.4.5" />
-    <PackageVersion Include="Microsoft.ClearScript.V8.ICUData" Version="7.4.5" />
-    <PackageVersion Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.4.5" />
-    <PackageVersion Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.4.5" />
+    <PackageVersion Include="Microsoft.ClearScript.V8" Version="7.5.0" />
+    <PackageVersion Include="Microsoft.ClearScript.V8.ICUData" Version="7.5.0" />
+    <PackageVersion Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.5.0" />
+    <PackageVersion Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.5.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.553101" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.17" />

--- a/Trell.Engine/ClearScriptWrappers/EngineWrapper.cs
+++ b/Trell.Engine/ClearScriptWrappers/EngineWrapper.cs
@@ -226,8 +226,11 @@ public class EngineWrapper : IDisposable {
             object module;
 
             using (var t = Cancel(this.engine, linked, this.currentContext).After(limits.MaxStartupDuration)) {
-                var loadWorkerJs = $"import * as hooks from '{work.WorkerJs}'; hooks;";
-                module = this.engine.Evaluate(docInfo, loadWorkerJs);
+                var loadWorkerJs = $"import('{work.WorkerJs}')";
+                var loadEvaluation = this.engine.Evaluate(work.WorkerJs.ToString(), false, loadWorkerJs);
+
+                module = loadEvaluation is Task<object> loadTask ? await loadTask : loadEvaluation;
+
                 Log.Information("Evaluated `{Js}` to {M}", loadWorkerJs, module);
 
                 if (module is Task<object> moduleResultTask) {

--- a/Trell.Engine/ClearScriptWrappers/EngineWrapper.cs
+++ b/Trell.Engine/ClearScriptWrappers/EngineWrapper.cs
@@ -193,7 +193,7 @@ public class EngineWrapper : IDisposable {
         return arr;
     }
 
-    public IArrayBuffer CreateJsBuffer(byte[] contents) {
+    public IArrayBuffer CreateJsBuffer(ReadOnlySpan<byte> contents) {
         var buf = (IArrayBuffer)((ScriptObject)this.engine.Evaluate("ArrayBuffer")).Invoke(true, [contents.Length]);
         if (contents.Length > 0) {
             buf.WriteBytes(contents, 0, (ulong)contents.Length, 0);
@@ -201,7 +201,7 @@ public class EngineWrapper : IDisposable {
         return buf;
     }
 
-    public ScriptObject CreateJsFile(string filename, string type, byte[] contents) {
+    public ScriptObject CreateJsFile(string filename, string type, ReadOnlySpan<byte> contents) {
         return (ScriptObject)((ScriptObject)this.engine.Evaluate("File")).Invoke(
             true,
             [

--- a/Trell.Engine/ClearScriptWrappers/EngineWrapper.cs
+++ b/Trell.Engine/ClearScriptWrappers/EngineWrapper.cs
@@ -220,14 +220,12 @@ public class EngineWrapper : IDisposable {
             EnableSourceLoading(work.SourceDirectory);
             var limits = this.limits.RestrictBy(work.Limits);
 
-            var docInfo = new DocumentInfo {
-                Category = ModuleCategory.Standard
-            };
             object module;
 
             using (var t = Cancel(this.engine, linked, this.currentContext).After(limits.MaxStartupDuration)) {
-                var loadWorkerJs = $"import('{work.WorkerJs}')";
-                var loadEvaluation = this.engine.Evaluate(work.WorkerJs.ToString(), false, loadWorkerJs);
+                var workerFileName = work.WorkerJs.ToString();
+                var loadWorkerJs = $"import('{workerFileName}')";
+                var loadEvaluation = this.engine.Evaluate(workerFileName, false, loadWorkerJs);
 
                 module = loadEvaluation is Task<object> loadTask ? await loadTask : loadEvaluation;
 
@@ -235,7 +233,7 @@ public class EngineWrapper : IDisposable {
 
                 if (module is Task<object> moduleResultTask) {
                     throw new TrellUserException(
-                        new TrellError(TrellErrorCode.TIMEOUT, $"worker.js took longer than {limits.MaxStartupDuration} to load"));
+                        new TrellError(TrellErrorCode.TIMEOUT, $"{workerFileName} took longer than {limits.MaxStartupDuration} to load"));
                 }
             }
 

--- a/Trell/Rpc/ToEngine.cs
+++ b/Trell/Rpc/ToEngine.cs
@@ -80,12 +80,10 @@ static class ToEngine {
                     ["url"] = fn.OnRequest.Url,
                     ["method"] = fn.OnRequest.Method,
                     ["headers"] = engine.CreateScriptObject(fn.OnRequest.Headers.ToDictionary(x => x.Key, y => (object)y.Value)),
-                    // TODO: Replace this with Span<> equivalent once ClearScript is updated to support it:
-                    // https://github.com/xledger/trell/issues/28
-                    ["body"] = engine.CreateJsBuffer(fn.OnRequest.Body.ToByteArray()),
+                    ["body"] = engine.CreateJsBuffer(fn.OnRequest.Body.Span),
                 })),
             Function.ValueOneofCase.OnUpload => new EngineWrapper.Work.RawArg("file", 
-                engine.CreateJsFile(fn.OnUpload.Filename, fn.OnUpload.Type, fn.OnUpload.Content.ToByteArray())
+                engine.CreateJsFile(fn.OnUpload.Filename, fn.OnUpload.Type, fn.OnUpload.Content.Span)
             ),
             Function.ValueOneofCase.Dynamic =>
                 new EngineWrapper.Work.RawArg("argv", engine.CreateJsStringArray(fn.Dynamic.Arguments)),


### PR DESCRIPTION
Switched ArrayBuffer creation to use ReadOnlySpan<byte> instead of byte[] to prevent creating an unnecessary extra copy of data